### PR TITLE
resolved coverage/coveralls failure, reintroduced flake8-import-order.

### DIFF
--- a/mssqlcli/cli.py
+++ b/mssqlcli/cli.py
@@ -14,13 +14,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+
 import os
+
 import click
+import pymssql
 
 from mssqlcli import formats
 from mssqlcli.config import Config
-
-import pymssql
 
 
 @click.group()

--- a/mssqlcli/config.py
+++ b/mssqlcli/config.py
@@ -14,7 +14,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+
 import re
+
 import keyring
 import yaml
 

--- a/mssqlcli/test_cli.py
+++ b/mssqlcli/test_cli.py
@@ -14,11 +14,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+
 import json
 
-from click.testing import CliRunner
-
 import mock
+
+from click.testing import CliRunner
 
 from mssqlcli import cli
 from mssqlcli import test_fixtures

--- a/tox-requirements.txt
+++ b/tox-requirements.txt
@@ -3,5 +3,4 @@ mock
 pytest
 coverage
 coveralls
-flake8
 tox

--- a/tox.ini
+++ b/tox.ini
@@ -20,32 +20,34 @@ norecursedirs=.tox .git venv
 
 [testenv:py27]
 commands=
-    coverage run --source=mssqlicli -m pytest
+    coverage run -m pytest -v --strict mssqlcli
 
 [testenv:py34]
 commands=
-    coverage run --source=mssqlicli -m pytest
+    coverage run -m pytest -v --strict mssqlcli
 
 [testenv:py35]
 commands=
-    coverage run --source=mssqlicli -m pytest
+    coverage run -m pytest -v --strict mssqlcli
 
 [testenv:py27verbose]
 basepython=python
 commands=
-    coverage run --source=mssqlicli -m pytest
+    coverage run -m pytest -v --strict mssqlcli
     coverage report -m
 
 [testenv:py35verbose]
 basepython=python3.5
 commands=
-    coverage run --source=mssqlicli -m pytest
+    coverage run -m pytest -v --strict mssqlcli
     coverage report -m
 
 [testenv:pep8]
 basepython = python2
 deps =
+        -rtox-requirements.txt
 	flake8
+        flake8-import-order
 	pep8-naming
 commands =
 	flake8 .
@@ -53,7 +55,9 @@ commands =
 [testenv:py3pep8]
 basepython = python3
 deps =
+        -rtox-requirements.txt
 	flake8
+        flake8-import-order
 	pep8-naming
 commands =
 	flake8 .
@@ -61,3 +65,4 @@ commands =
 [flake8]
 exclude = .tox,*.egg
 select = E,W,F,N,I
+import-order-style = smarkets


### PR DESCRIPTION
- modified coverage command to run correctly inside tox.
- added flake8-import-order back into tox.ini
- swapped import order to smarkets
- fixed the resulting three errors from import-order.

Triggered a Travis-CI build for the modified branch, should be able to confirm soon that it works:

https://travis-ci.org/rtrox/mssqlcli/builds/169788653
https://coveralls.io/builds/8461551

Thanks again for working on this PR!